### PR TITLE
docs: 更新 README 中的构建状态徽章链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 <p align="center"><img src="./assets/logo.png" alt="logo" width="400"></p>
 
 <p align="center">
-<a href="https://github.com/waplar/framework/actions"><img src="https://github.com/waplar/framework/workflows/pest/badge.svg" alt="Build Status"></a>
+<a href="https://github.com/waplar/framework/actions"><img src="https://github.com/waplar/framework/actions/workflows/pest.yml/badge.svg?branch=alpha.x
+" alt="Build Status"></a>
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/waplar/framework" alt="Total Downloads"></a>
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/waplar/framework" alt="Latest Stable Version"></a>
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/waplar/framework" alt="License"></a>


### PR DESCRIPTION
- 修改了构建状态徽章的链接地址，使其指向具体的 pest.yml 工作流程
- 添加了 branch 参数，指定为 alpha.x 分支