### PR TITLE
docs: 更新 README 中的包管理器链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <p align="center">
 <a href="https://github.com/waplar/framework/actions"><img src="https://github.com/waplar/framework/actions/workflows/pest.yml/badge.svg?branch=alpha.x" alt="Test Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/waplar/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/waplar/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/waplar/framework" alt="License"></a>
+<a href="https://packagist.org/packages/waplar/framework"><img src="https://img.shields.io/packagist/dt/waplar/framework" alt="Total Downloads"></a>
+<a href="https://packagist.org/packages/waplar/framework"><img src="https://img.shields.io/packagist/v/waplar/framework" alt="Latest Stable Version"></a>
+<a href="https://packagist.org/packages/waplar/framework"><img src="https://img.shields.io/packagist/l/waplar/framework" alt="License"></a>
 </p>
 
 ## Introduction


### PR DESCRIPTION
- 将 Laravel框架的包管理器链接替换为 Waplar 框架的正确链接
- 修复了显示总下载量、最新稳定版本和许可证的徽章图像链接