### PR TITLE
ci:为 subtree 工作流添加必要的权限

### DIFF
--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -5,6 +5,10 @@ on:
         tags:
             - '*'
 
+permissions:
+    contents: write
+    id-token: write
+
 jobs:
     sync-subtrees:
         runs-on: ubuntu-latest


### PR DESCRIPTION
- 添加 contents 和 id-token 权限，以满足 subtree 同步操作的需要