### PR TITLE
ci:移除 subtree 工作流中的 releases 权限- 删除了 .github/workflows/subtree.yml 文件…

### DIFF
--- a/.github/workflows/subtree.yml
+++ b/.github/workflows/subtree.yml
@@ -10,8 +10,6 @@ jobs:
         permissions:
             contents: write
             id-token: write
-            # 新增Release创建权限
-            releases: write
 
         steps:
             -   name: Checkout Code


### PR DESCRIPTION
…中的 releases 权限配置

- 保留了 contents 和 id-token 的写入权限
- 移除了多余的注释