### PR TITLE
refactor(Preacher): 重构基础结构和默认值设置

### DIFF
--- a/src/Illustrator/Preacher/Builder.php
+++ b/src/Illustrator/Preacher/Builder.php
@@ -29,14 +29,14 @@ class Builder
     private array $data = [];
 
     /**
-     * @param Closure $hook
-     * @param string  $msg
-     * @param int     $statusCode
+     * @param  Closure  $hook
+     * @param  string   $msg
+     * @param  int      $statusCode
      */
     public function __construct(
         Closure $hook,
-        string $msg = '',
-        int $statusCode = Constants\CodeStatus::SUCCEED
+        string $msg = Constants\DefaultSetting::MSG,
+        int $statusCode = Constants\DefaultSetting::STATUS_CODE
     ) {
         $this->setHook($hook);
         $this->setMsg($msg);
@@ -44,7 +44,17 @@ class Builder
     }
 
     /**
-     * @param stdClass $value
+     * @param  Closure  $value
+     *
+     * @return void
+     */
+    private function setHook(Closure $value): void
+    {
+        $this->hook = $value;
+    }
+
+    /**
+     * @param  stdClass  $value
      *
      * @return static
      */
@@ -56,7 +66,7 @@ class Builder
     }
 
     /**
-     * @param array $value
+     * @param  array  $value
      *
      * @return static
      */
@@ -68,18 +78,18 @@ class Builder
     }
 
     /**
-     * @param int   $page
-     * @param int   $prePage
-     * @param int   $total
-     * @param array $rows
+     * @param  int    $page
+     * @param  int    $pages
+     * @param  int    $total
+     * @param  array  $rows
      *
      * @return static
      */
-    public function setPaging(int $page, int $prePage, int $total, array $rows): static
+    public function setPaging(int $page, int $pages, int $total, array $rows): static
     {
         $this->data['paging'] = (object) [
             'page' => $page,
-            'prePage' => $prePage,
+            'pages' => $pages,
             'total' => $total,
             'rows' => $rows,
         ];
@@ -107,7 +117,7 @@ class Builder
     }
 
     /**
-     * @param int $statusCode
+     * @param  int  $statusCode
      *
      * @return static
      */
@@ -130,7 +140,7 @@ class Builder
     }
 
     /**
-     * @param string $message
+     * @param  string  $message
      *
      * @return static
      */
@@ -139,6 +149,14 @@ class Builder
         $this->msg = $message;
 
         return $this;
+    }
+
+    /**
+     * @return Closure
+     */
+    private function getHook(): Closure
+    {
+        return $this->hook;
     }
 
     /**
@@ -179,24 +197,6 @@ class Builder
             'total' => 0,
             'rows' => [],
         ];
-    }
-
-    /**
-     * @param Closure $value
-     *
-     * @return void
-     */
-    private function setHook(Closure $value): void
-    {
-        $this->hook = $value;
-    }
-
-    /**
-     * @return Closure
-     */
-    private function getHook(): Closure
-    {
-        return $this->hook;
     }
 
 }

--- a/src/Illustrator/Preacher/Constants/DefaultSetting.php
+++ b/src/Illustrator/Preacher/Constants/DefaultSetting.php
@@ -33,4 +33,14 @@ class DefaultSetting
      */
     public const JSON_OPTIONS = JSON_UNESCAPED_UNICODE;
 
+    /**
+     * Default message key's value
+     */
+    public const MSG = '';
+
+    /**
+     * Default status code's value
+     */
+    public const STATUS_CODE = StatusCode::SUCCEED;
+
 }

--- a/src/Illustrator/Preacher/Constants/StatusCode.php
+++ b/src/Illustrator/Preacher/Constants/StatusCode.php
@@ -2,7 +2,7 @@
 
 namespace Illustrator\Preacher\Constants;
 
-class CodeStatus
+class StatusCode
 {
 
     /**

--- a/src/Illustrator/Preacher/Preacher.php
+++ b/src/Illustrator/Preacher/Preacher.php
@@ -14,7 +14,7 @@ class Preacher
     private static Closure $hook;
 
     /**
-     * @param Closure $callable
+     * @param  Closure  $callable
      */
     public static function useHook(Closure $callable): void
     {
@@ -22,53 +22,20 @@ class Preacher
     }
 
     /**
-     * @param string $msg
+     * @param  string  $msg
+     * @param  int     $statusCode
      *
      * @return Builder
      */
-    public static function basic(string $msg): Builder
+    public static function basic(
+        string $msg = Constants\DefaultSetting::MSG,
+        int $statusCode = Constants\DefaultSetting::STATUS_CODE
+    ): Builder
     {
         return new Builder(
             hook: self::getHook(),
-            msg: $msg
-        );
-    }
-
-    /**
-     * @param array $value
-     *
-     * @return Builder
-     */
-    public static function rows(array $value): Builder
-    {
-        return (new Builder(hook: self::getHook()))->setRows($value);
-    }
-
-    /**
-     * @param stdClass $value
-     *
-     * @return Builder
-     */
-    public static function receipt(stdClass $value): Builder
-    {
-        return (new Builder(hook: self::getHook()))->setReceipt($value);
-    }
-
-    /**
-     * @param int   $page
-     * @param int   $prePage
-     * @param int   $total
-     * @param array $rows
-     *
-     * @return Builder
-     */
-    public static function paging(int $page, int $prePage, int $total, array $rows): Builder
-    {
-        return (new Builder(hook: self::getHook()))->setPaging(
-            page: $page,
-            prePage: $prePage,
-            total: $total,
-            rows: $rows
+            msg: $msg,
+            statusCode: $statusCode
         );
     }
 
@@ -80,6 +47,44 @@ class Preacher
         return self::$hook ?? function (string $msg, array $data) {
             return [$msg, $data];
         };
+    }
+
+    /**
+     * @param  array  $value
+     *
+     * @return Builder
+     */
+    public static function rows(array $value): Builder
+    {
+        return (new Builder(hook: self::getHook()))->setRows($value);
+    }
+
+    /**
+     * @param  stdClass  $value
+     *
+     * @return Builder
+     */
+    public static function receipt(stdClass $value): Builder
+    {
+        return (new Builder(hook: self::getHook()))->setReceipt($value);
+    }
+
+    /**
+     * @param  int    $page
+     * @param  int    $pages
+     * @param  int    $total
+     * @param  array  $rows
+     *
+     * @return Builder
+     */
+    public static function paging(int $page, int $pages, int $total, array $rows): Builder
+    {
+        return (new Builder(hook: self::getHook()))->setPaging(
+            page: $page,
+            pages: $pages,
+            total: $total,
+            rows: $rows
+        );
     }
 
 }


### PR DESCRIPTION
- 修改了 Builder 类的构造函数参数，默认值使用 Constants\DefaultSetting 类中的常量
- 重命名 CodeStatus 类为 StatusCode，提高代码清晰度
- 优化了 Preacher 类中的方法参数和默认值设置
- 调整了 DefaultSetting 类，添加了默认的消息和状态码常量
- 修改了 Builder 类中的私有方法 setHook 和 getHook，提高代码封装性