### PR TITLE
refactor(waiter): 优化迁移生成器并调整测试用例- 移除了 test_case_one、test_case_two 和 test_case_four 中不必要的 summary() 方法调用

### DIFF
--- a/artist/waiter/test_case_four.php
+++ b/artist/waiter/test_case_four.php
@@ -17,7 +17,7 @@ return Waiter::configure()->withTable(
         'uuid',
     ]);
 
-    $blueprint->bigInteger('id', true)->summary()->primary()->unique()->comment('ID');
+    $blueprint->bigInteger('id', true)->primary()->unique()->comment('ID');
 
     $blueprint->ulid();
     $blueprint->uuid();
@@ -26,7 +26,7 @@ return Waiter::configure()->withTable(
         $blueprint->bigInteger('created_at')->comment('Created'),
         $blueprint->bigInteger('updated_at')->comment('Updated'),
     ], function (ColumnDefinition $definition) {
-        return $definition->summary()->cast(AutoTimezone::class)->fillable();
+        return $definition->cast(AutoTimezone::class)->fillable();
     });
 })->withModel(
     Model::class

--- a/artist/waiter/test_case_one.php
+++ b/artist/waiter/test_case_one.php
@@ -17,13 +17,13 @@ return Waiter::configure()->withTable(
         $blueprint->string('explain', 64)->nullable()->comment('Explain'),
         $blueprint->string('route')->comment('Route name'),
     ], function (ColumnDefinition $definition) {
-        return $definition->summary()->fillable();
+        return $definition->fillable();
     });
 
     $blueprint->group([
         $blueprint->bigInteger('created_at')->comment('Created'),
         $blueprint->bigInteger('updated_at')->comment('Updated'),
     ], function (ColumnDefinition $definition) {
-        return $definition->summary()->cast(AutoTimezone::class)->fillable();
+        return $definition->cast(AutoTimezone::class)->fillable();
     });
 });

--- a/artist/waiter/test_case_two.php
+++ b/artist/waiter/test_case_two.php
@@ -9,12 +9,12 @@ return Waiter::configure()->withTable(
     'case_two',
     'Test case two'
 )->withBlueprint(function (Blueprint $blueprint) {
-    $blueprint->bigInteger('id')->summary()->primary()->unique()->comment('ID');
+    $blueprint->bigInteger('id')->primary()->unique()->comment('ID');
 
     $blueprint->group([
         $blueprint->bigInteger('created_at')->comment('Created'),
         $blueprint->bigInteger('updated_at')->comment('Updated'),
     ], function (ColumnDefinition $definition) {
-        return $definition->summary()->cast(AutoTimezone::class)->fillable();
+        return $definition->cast(AutoTimezone::class)->fillable();
     });
 })->withSummary('', 'CaseTwo');

--- a/src/Illustrator/Waiter/Builders/Migration/UpCreate.php
+++ b/src/Illustrator/Waiter/Builders/Migration/UpCreate.php
@@ -103,6 +103,7 @@ class UpCreate extends Builder
                     'unsigned',
                     'useCurrent',
                     'useCurrentOnUpdate',
+                    'nullable',
                 ])) {
                     return "$key()";
                 }
@@ -170,6 +171,7 @@ class UpCreate extends Builder
         return match (gettype($value)) {
             'string' => "'$value'",
             'boolean' => $value ? 'true' : 'false',
+            'integer' => $value,
             'array' => $this->arrayToCode($value),
             default => gettype($value),
         };


### PR DESCRIPTION
- 调整了 AutoTimezone 铸造方法的使用方式
- 在 UpCreate 类中添加了对 'nullable' 属性的支持
- 优化了 UpCreate 类中的 valueToCode 方法，增加了对整数类型的处理