### PR TITLE
refactor(Preacher): 重构 Builder 类并添加 modelToObject 方法- 在 Builder 类中添加 …

### DIFF
--- a/src/Illustrator/Preacher/Builder.php
+++ b/src/Illustrator/Preacher/Builder.php
@@ -3,6 +3,7 @@
 namespace Illustrator\Preacher;
 
 use Closure;
+use Illuminate\Database\Eloquent\Model;
 use Illustrator\Preacher\Constants\DefaultSetting;
 use stdClass;
 
@@ -45,9 +46,9 @@ class Builder
     private array $jsonResponse;
 
     /**
-     * @param Closure $hook
-     * @param string  $msg
-     * @param int     $statusCode
+     * @param  Closure  $hook
+     * @param  string   $msg
+     * @param  int      $statusCode
      */
     public function __construct(
         Closure $hook,
@@ -72,8 +73,8 @@ class Builder
     }
 
     /**
-     * @param int  $options
-     * @param bool $json
+     * @param  int   $options
+     * @param  bool  $json
      *
      * @return static
      */
@@ -93,7 +94,7 @@ class Builder
     }
 
     /**
-     * @param int $value
+     * @param  int  $value
      *
      * @return static
      */
@@ -105,7 +106,7 @@ class Builder
     }
 
     /**
-     * @param array $value
+     * @param  array  $value
      *
      * @return static
      */
@@ -133,7 +134,7 @@ class Builder
     }
 
     /**
-     * @param stdClass $value
+     * @param  stdClass  $value
      *
      * @return static
      */
@@ -145,7 +146,7 @@ class Builder
     }
 
     /**
-     * @param array $value
+     * @param  array  $value
      *
      * @return static
      */
@@ -157,10 +158,10 @@ class Builder
     }
 
     /**
-     * @param int   $page
-     * @param int   $pages
-     * @param int   $total
-     * @param array $rows
+     * @param  int    $page
+     * @param  int    $pages
+     * @param  int    $total
+     * @param  array  $rows
      *
      * @return static
      */
@@ -196,7 +197,7 @@ class Builder
     }
 
     /**
-     * @param int $statusCode
+     * @param  int  $statusCode
      *
      * @return static
      */
@@ -219,7 +220,7 @@ class Builder
     }
 
     /**
-     * @param string $message
+     * @param  string  $message
      *
      * @return static
      */
@@ -271,7 +272,7 @@ class Builder
     }
 
     /**
-     * @param Closure $value
+     * @param  Closure  $value
      *
      * @return void
      */
@@ -286,6 +287,16 @@ class Builder
     private function getHook(): Closure
     {
         return $this->hook;
+    }
+
+    /**
+     * @param  Model  $model
+     *
+     * @return stdClass
+     */
+    public function modelToObject(Model $model): stdClass
+    {
+        return (object) $model->toArray();
     }
 
 }

--- a/src/Illustrator/Preacher/Response/JsonResponse.php
+++ b/src/Illustrator/Preacher/Response/JsonResponse.php
@@ -17,7 +17,7 @@ class JsonResponse extends Response
     public function __construct(Builder $builder)
     {
         parent::__construct(
-            $builder->getData(),
+            $builder->getResponse(),
             $builder->getHttpStatus(),
             $builder->getHeaders(),
             $builder->getJsonResponse()['options'],


### PR DESCRIPTION
…modelToObject 方法，用于将 Eloquent 模型转换为 stdClass 对象

- 修改 JsonResponse 构造方法，使用 Builder 类的 getResponse 方法获取数据
- 优化 Builder 类的属性和方法注释，提高代码可读性